### PR TITLE
WIP: Edge support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 
 ## [Unreleased]
+### Added
+- Support for Microsoft Edge
+
 ### Changes
 - No permissions are requested anymore
 

--- a/nein.js
+++ b/nein.js
@@ -1,16 +1,29 @@
-chrome.tabs.onCreated.addListener(function(tab) {
-  chrome.windows.get(tab.windowId, { populate: true }, function(currentWindow) {
-    if (currentWindow.tabs.length > 9) {
-      chrome.windows.get(tab.windowId, function(currentWindow) {
-        var createOptions = {
-          tabId: tab.id,
-          incognito: tab.incognito,
-          state: currentWindow.state
-        };
+var browser = (function() {
+  return window.browser || window.chrome;
+})();
 
-        chrome.windows.create(createOptions);
+browser.tabs.onCreated.addListener(function(tab) {
+  browser.windows.get(tab.windowId, { populate: true }, function(currentWindow) {
+    if (currentWindow.tabs.length > 9) {
+      browser.windows.get(tab.windowId, function(currentWindow) {
+        browser.windows.create(optionsForNewWindow(tab, currentWindow));
       });
     }
   });
 });
+
+function optionsForNewWindow(tab, oldWindow) {
+  var options = {
+    tabId: tab.id,
+    state: oldWindow.state
+  };
+
+  if (tab.hasOwnProperty("incognito")) {
+    options.incognito = tab.incognito;
+  } else {
+    options.inPrivate = tab.inPrivate;
+  }
+
+  return options;
+}
 


### PR DESCRIPTION
Microsoft's WebExtension API behaves slightly different to Chrome, Firefox and Opera's.

Currently `browser.windows.get`'s callback gets executed twice and the second time the callback doesn't have the `currentWindow` parameter set.
Not sure if that's because of a bug in Edge or not. But in all other browsers it only gets executed once.

Additionally the new window that opens does not contain the original tab yet.

Right now the behaviour seen in Edge is that the 10th tab does trigger opening a new window, but the tab stays in the original window.